### PR TITLE
Added a _repr_png_

### DIFF
--- a/pydot/pydot.py
+++ b/pydot/pydot.py
@@ -27,6 +27,7 @@ import re
 import subprocess
 import tempfile
 import copy
+
 try:
     import dot_parser
 except Exception, e:
@@ -1910,6 +1911,15 @@ class Dot(Graph):
         dot_fd.close()
 
         return True
+
+
+    def _repr_png_(self):
+        """IPython display hook support.
+        """
+        png_filename = tempfile.mktemp('.png')
+        self.write_png(png_filename)
+        with open(png_filename, 'rb') as f:
+            return f.read()
 
 
 

--- a/pydot/pydot.py
+++ b/pydot/pydot.py
@@ -1921,7 +1921,13 @@ class Dot(Graph):
         with open(png_filename, 'rb') as f:
             return f.read()
 
-
+    def _repr_svg_(self):
+        """IPython display hook support.
+        """
+        svg_filename = tempfile.mktemp('.svg')
+        self.write_svg(svg_filename)
+        with open(svg_filename, 'rb') as f:
+            return f.read().decode('utf8') # svg formatter expects str
 
     def create(self, prog=None, format='ps'):
         """Creates and returns a Postscript representation of the graph.


### PR DESCRIPTION
`_repr_png` uses `write_png` to implement an IPython notebook display hook so that graphs could be displayed in the notebook:

``` py
g = Dot()
node = pydot.Node('Node')
g.add_node(node)
g
```

(previous version implemented `Graph.to_png` but then I figured I can just use `Dot.write_png`).
